### PR TITLE
Fix typo that returned channel 1 advance for all channels

### DIFF
--- a/src/ignitech.cpp
+++ b/src/ignitech.cpp
@@ -521,21 +521,21 @@ int IGNITECH::get_advance1() {
 	Simple Getter
 */
 int IGNITECH::get_advance2() {
-	return ignition.advance_1_deg;
+	return ignition.advance_2_deg;
 }
 
 /*
 	Simple Getter
 */
 int IGNITECH::get_advance3() {
-	return ignition.advance_1_deg;
+	return ignition.advance_3_deg;
 }
 
 /*
 	Simple Getter
 */
 int IGNITECH::get_advance4() {
-	return ignition.advance_1_deg;
+	return ignition.advance_4_deg;
 }
 
 /*


### PR DESCRIPTION
Simple typo, was not caught by test suite because the test runs all channels at the same time.
Closes #13 
